### PR TITLE
Use scatter-clip as a default clip-path. Solves issues with clippath not...

### DIFF
--- a/examples/public/docs/renderer_base.html
+++ b/examples/public/docs/renderer_base.html
@@ -211,6 +211,7 @@ which is very not desired.</p>
       .data([<span class="property">@series</span>.stack])
       .enter()
       .append(<span class="string">"g"</span>)
+      .attr(<span class="string">"clip-path"</span>, <span class="string">"url(#scatter-clip)"</span>)
       .attr(<span class="string">'id'</span>, <span class="property">@_nameToId</span>())
       .attr(<span class="string">'class'</span>, <span class="property">@name</span>)
       

--- a/src/coffee/util/base_renderer.coffee
+++ b/src/coffee/util/base_renderer.coffee
@@ -84,6 +84,7 @@ Tactile.RendererBase = class RendererBase
       .data([@series.stack])
       .enter()
       .append("g")
+      .attr("clip-path", "url(#scatter-clip)")
       .attr('id', @_nameToId())
       .attr('class', @name)
 


### PR DESCRIPTION
... being respected at the first time the chart is rendered
