### PR TITLE
Charts should default to correct colors

### DIFF
--- a/public/assets/tactile.css
+++ b/public/assets/tactile.css
@@ -1,255 +1,255 @@
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000369}}
+/* line 69, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-blue-10 {
   fill: #0b3748; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000370}}
+/* line 70, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-blue-20 {
   fill: #254e5d; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000371}}
+/* line 71, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-blue-30 {
   fill: #3f6672; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000372}}
+/* line 72, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-blue-40 {
   fill: #597d88; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000373}}
+/* line 73, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-blue-50 {
   fill: #73959d; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000374}}
+/* line 74, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-blue-60 {
   fill: #8eadb3; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000377}}
+/* line 77, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-blue-10 {
   fill: #0c1b75; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000378}}
+/* line 78, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-blue-20 {
   fill: #263683; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000379}}
+/* line 79, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-blue-30 {
   fill: #405192; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000380}}
+/* line 80, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-blue-40 {
   fill: #5a6ca1; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000381}}
+/* line 81, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-blue-50 {
   fill: #7487b0; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000382}}
+/* line 82, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-blue-60 {
   fill: #8fa3bf; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000385}}
+/* line 85, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-azure-10 {
   fill: #003fc1; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000386}}
+/* line 86, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-azure-20 {
   fill: #2058c8; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000387}}
+/* line 87, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-azure-30 {
   fill: #4072d0; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000388}}
+/* line 88, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-azure-40 {
   fill: #608bd7; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000389}}
+/* line 89, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-azure-50 {
   fill: #80a5df; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000390}}
+/* line 90, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-azure-60 {
   fill: #a0bfe7; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000393}}
+/* line 93, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-light-blue-10 {
   fill: #4727c0; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000394}}
+/* line 94, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-light-blue-20 {
   fill: #6043c8; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000395}}
+/* line 95, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-light-blue-30 {
   fill: #795fd0; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000396}}
+/* line 96, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-light-blue-40 {
   fill: #927bd8; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000397}}
+/* line 97, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-light-blue-50 {
   fill: #ab87e0; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\0000398}}
+/* line 98, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-light-blue-60 {
   fill: #c5b3e9; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003101}}
+/* line 101, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-barn-red-10 {
   fill: #4e0002; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003102}}
+/* line 102, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-barn-red-20 {
   fill: #671e20; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003103}}
+/* line 103, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-barn-red-30 {
   fill: #813d3f; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003104}}
+/* line 104, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-barn-red-40 {
   fill: #9a5c5d; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003105}}
+/* line 105, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-barn-red-50 {
   fill: #b47b7c; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003106}}
+/* line 106, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-barn-red-60 {
   fill: #ce9a9b; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003109}}
+/* line 109, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-scarlet-red-10 {
   fill: #d21e17; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003110}}
+/* line 110, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-scarlet-red-20 {
   fill: #d83c36; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003111}}
+/* line 111, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-scarlet-red-30 {
   fill: #de5a55; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003112}}
+/* line 112, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-scarlet-red-40 {
   fill: #e47975; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003113}}
+/* line 113, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-scarlet-red-50 {
   fill: #ea9794; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003114}}
+/* line 114, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-scarlet-red-60 {
   fill: #f0b6b4; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003117}}
+/* line 117, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-alloy-orange-10 {
   fill: #c07200; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003118}}
+/* line 118, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-alloy-orange-20 {
   fill: #c98621; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003119}}
+/* line 119, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-alloy-orange-30 {
   fill: #d39a42; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003120}}
+/* line 120, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-alloy-orange-40 {
   fill: #ddaf63; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003121}}
+/* line 121, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-alloy-orange-50 {
   fill: #e7c384; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003122}}
+/* line 122, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-alloy-orange-60 {
   fill: #f1d8a6; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003125}}
+/* line 125, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-brown-10 {
   fill: #623c1c; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003126}}
+/* line 126, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-brown-20 {
   fill: #79593d; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003127}}
+/* line 127, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-brown-30 {
   fill: #90765f; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003128}}
+/* line 128, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-brown-40 {
   fill: #a79380; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003129}}
+/* line 129, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-brown-50 {
   fill: #beb0a2; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003130}}
+/* line 130, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-brown-60 {
   fill: #d6cdc4; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003133}}
+/* line 133, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-silver-grey-10 {
   fill: #777777; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003134}}
+/* line 134, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-silver-grey-20 {
   fill: #8a8a8a; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003135}}
+/* line 135, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-silver-grey-30 {
   fill: #9d9d9d; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003136}}
+/* line 136, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-silver-grey-40 {
   fill: #b1b1b1; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003137}}
+/* line 137, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-silver-grey-50 {
   fill: #c4c4c4; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003138}}
+/* line 138, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-silver-grey-60 {
   fill: #d8d8d8; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003141}}
+/* line 141, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-grey-10 {
   fill: #414343; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003142}}
+/* line 142, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-grey-20 {
   fill: #4d4f4f; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003143}}
+/* line 143, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-grey-30 {
   fill: #5a5b5b; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003144}}
+/* line 144, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-grey-40 {
   fill: #676868; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003145}}
+/* line 145, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-grey-50 {
   fill: #747474; }
 
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_tactile_colors\.scss}line{font-family:\00003146}}
+/* line 146, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_tactile_colors.scss */
 .tactile-dark-grey-60 {
   fill: #818181; }
 
-@media -sass-debug-info{filename{}line{font-family:\000039}}
+/* line 9 */
 #chart {
   width: 938px;
   height: 300px;
   overflow: hidden; }
 
-@media -sass-debug-info{filename{}line{font-family:\0000315}}
+/* line 15 */
 #chart-container {
   border: 1px solid #e6e6e6;
   margin-top: 20px;
   position: relative; }
-@media -sass-debug-info{filename{}line{font-family:\0000319}}
+  /* line 19 */
   #chart-container .uncategorized {
     position: absolute;
     top: 0;
@@ -259,7 +259,7 @@
     border-left: 1px solid #e6e6e6;
     border-bottom: 1px solid #e6e6e6;
     background: #fff; }
-@media -sass-debug-info{filename{}line{font-family:\0000329}}
+  /* line 29 */
   #chart-container .empty {
     background: #F2F2F3;
     color: #9B9DA1;
@@ -272,19 +272,19 @@
     width: 938px; }
 
 /* graph */
-@media -sass-debug-info{filename{}line{font-family:\0000343}}
+/* line 43 */
 .chart-container {
   position: relative; }
 
-@media -sass-debug-info{filename{}line{font-family:\0000347}}
+/* line 47 */
 .chart-widget {
   padding-left: 0; }
 
-@media -sass-debug-info{filename{}line{font-family:\0000351}}
+/* line 51 */
 .main-d3-chart.graph-container {
   left: 15px; }
 
-@media -sass-debug-info{filename{}line{font-family:\0000355}}
+/* line 55 */
 .graph-container svg * {
   -moz-user-select: -moz-none;
   -khtml-user-select: none;
@@ -297,62 +297,62 @@
   user-select: none; }
 
 /* Specific rules for mini-charts */
-@media -sass-debug-info{filename{}line{font-family:\0000370}}
+/* line 70 */
 .mini-chart-container.graph-container .gauge path {
   stroke: none; }
-@media -sass-debug-info{filename{}line{font-family:\0000375}}
+/* line 75 */
 .mini-chart-container.graph-container path {
   stroke: #30878f;
   stroke-width: 2; }
-@media -sass-debug-info{filename{}line{font-family:\0000379}}
+/* line 79 */
 .mini-chart-container.graph-container rect {
   stroke-width: .3;
   stroke: white;
   fill: #30878f; }
 
-@media -sass-debug-info{filename{}line{font-family:\0000386}}
+/* line 86 */
 .mini-chart-container {
   height: 38px; }
 
-@media -sass-debug-info{filename{}line{font-family:\0000390}}
+/* line 90 */
 .metric-inner-container {
   height: 225px; }
-@media -sass-debug-info{filename{}line{font-family:\0000393}}
+  /* line 93 */
   .metric-inner-container .bar {
     fill: #30878f; }
 
-@media -sass-debug-info{filename{}line{font-family:\0000398}}
+/* line 98 */
 .metric-inner-container, .graph-container {
   position: relative; }
-@media -sass-debug-info{filename{}line{font-family:\00003101}}
+  /* line 101 */
   .metric-inner-container svg, .graph-container svg {
     display: block;
     overflow: hidden; }
 
 /* axes */
-@media -sass-debug-info{filename{}line{font-family:\00003113}}
+/* line 113 */
 .y-ticks, .y1-ticks {
   /* Don't display first tick of Y-axis */ }
-@media -sass-debug-info{filename{}line{font-family:\00003115}}
+  /* line 115 */
   .y-ticks g:first-child, .y1-ticks g:first-child {
     opacity: 0 !important; }
-@media -sass-debug-info{filename{}line{font-family:\00003120}}
+  /* line 120 */
   .y-ticks.plain path, .y1-ticks.plain path {
     fill: none;
     stroke: none; }
-@media -sass-debug-info{filename{}line{font-family:\00003125}}
+  /* line 125 */
   .y-ticks.plain .tick, .y1-ticks.plain .tick {
     stroke: none; }
-@media -sass-debug-info{filename{}line{font-family:\00003129}}
+  /* line 129 */
   .y-ticks path, .y1-ticks path {
     fill: none;
     stroke: #808080; }
-@media -sass-debug-info{filename{}line{font-family:\00003134}}
+  /* line 134 */
   .y-ticks .tick, .y1-ticks .tick {
     stroke: rgba(0, 0, 0, 0.16);
     stroke-width: 2px;
     shape-rendering: crisp-edges; }
-@media -sass-debug-info{filename{}line{font-family:\00003141}}
+  /* line 141 */
   .y-ticks text, .y1-ticks text {
     opacity: 0.5;
     fill: black;
@@ -360,33 +360,33 @@
     text-transform: uppercase;
     font-weight: bold; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003152}}
+/* line 152 */
 .y-grid .tick {
   z-index: -1;
   stroke: rgba(0, 0, 0, 0.2);
   stroke-width: 1px;
   stroke-dasharray: 1 1; }
-@media -sass-debug-info{filename{}line{font-family:\00003158}}
+/* line 158 */
 .y-grid path {
   fill: none;
   stroke: none; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003166}}
+/* line 166 */
 .x-ticks.plain path {
   fill: none;
   stroke: none; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003172}}
+/* line 172 */
 .x-tick, .x-ticks {
   fill: black;
   position: absolute;
   top: 0;
   bottom: 0;
   width: 0px; }
-@media -sass-debug-info{filename{}line{font-family:\00003173}}
+  /* line 173 */
   .x-tick.grid, .x-ticks.grid {
     border-left: 1px dotted rgba(0, 0, 0, 0.2); }
-@media -sass-debug-info{filename{}line{font-family:\00003184}}
+  /* line 184 */
   .x-tick .title, .x-tick text, .x-ticks .title, .x-ticks text {
     font-size: 12px;
     text-transform: uppercase;
@@ -394,96 +394,96 @@
     opacity: 0.5;
     white-space: nowrap;
     text-anchor: middle; }
-@media -sass-debug-info{filename{}line{font-family:\00003193}}
+  /* line 193 */
   .x-tick.align-end .title, .x-ticks.align-end .title {
     text-anchor: end; }
-@media -sass-debug-info{filename{}line{font-family:\00003197}}
+  /* line 197 */
   .x-tick.align-start .title, .x-ticks.align-start .title {
     text-anchor: start; }
-@media -sass-debug-info{filename{}line{font-family:\00003201}}
+  /* line 201 */
   .x-tick.align-start .title, .x-ticks.align-start .title {
     text-anchor: middle; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003206}}
+/* line 206 */
 .x-tick.glow .title, .y-ticks.glow text {
   fill: black;
   color: black;
   text-shadow: -1px 1px 0 rgba(255, 255, 255, 0.1), 1px -1px 0 rgba(255, 255, 255, 0.1), 1px 1px 0 rgba(255, 255, 255, 0.1), 0px 1px 0 rgba(255, 255, 255, 0.1), 0px -1px 0 rgba(255, 255, 255, 0.1), 1px 0px 0 rgba(255, 255, 255, 0.1), -1px 0px 0 rgba(255, 255, 255, 0.1), -1px -1px 0 rgba(255, 255, 255, 0.1); }
 
-@media -sass-debug-info{filename{}line{font-family:\00003216}}
+/* line 216 */
 .x-tick.inverse .title, .y-ticks.inverse text {
   fill: white;
   color: white;
   text-shadow: -1px 1px 0 rgba(0, 0, 0, 0.8), 1px -1px 0 rgba(0, 0, 0, 0.8), 1px 1px 0 rgba(0, 0, 0, 0.8), 0px 1px 0 rgba(0, 0, 0, 0.8), 0px -1px 0 rgba(0, 0, 0, 0.8), 1px 0px 0 rgba(0, 0, 0, 0.8), -1px 0px 0 rgba(0, 0, 0, 0.8), -1px -1px 0 rgba(0, 0, 0, 0.8); }
 
-@media -sass-debug-info{filename{}line{font-family:\00003226}}
+/* line 226 */
 #y-axis {
   position: absolute;
   bottom: 0;
   width: 20px;
   left: 5px; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003233}}
+/* line 233 */
 .y-axis {
   fill: none; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003238}}
+/* line 238 */
 .axis.yAxis, .axis.xAxis {
   text-transform: uppercase !important;
   font-size: 11px;
   font-weight: bold;
   fill: #a69b9e; }
-@media -sass-debug-info{filename{}line{font-family:\00003243}}
+/* line 243 */
 .axis.yAxis line, .axis.yAxis path {
   stroke: #a69b9e;
   stroke-width: 2px; }
-@media -sass-debug-info{filename{}line{font-family:\00003248}}
+/* line 248 */
 .axis.yAxis .domain {
   stroke: none; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003254}}
+/* line 254 */
 .axis {
   shape-rendering: crispEdges; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003259}}
+/* line 259 */
 .xAxis.axis line {
   stroke: #fff; }
-@media -sass-debug-info{filename{}line{font-family:\00003263}}
+/* line 263 */
 .xAxis.axis .minor {
   stroke-opacity: .5; }
-@media -sass-debug-info{filename{}line{font-family:\00003267}}
+/* line 267 */
 .xAxis.axis path {
   display: none; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003272}}
+/* line 272 */
 .yAxis.axis line, .yAxis.axis path {
   fill: none;
   stroke: #000; }
 
 /* legend */
-@media -sass-debug-info{filename{}line{font-family:\00003280}}
+/* line 280 */
 #main-chart-legend .well {
   display: inline-block;
   padding: 5px; }
-@media -sass-debug-info{filename{}line{font-family:\00003285}}
+/* line 285 */
 #main-chart-legend .chart-legend {
   margin: 1px 0 0 15px;
   padding: 5px 0 0 0;
   list-style: none;
   *zoom: 1; }
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_mixins\.scss}line{font-family:\00003167}}
+  /* line 167, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_mixins.scss */
   #main-chart-legend .chart-legend:before, #main-chart-legend .chart-legend:after {
     display: table;
     content: ""; }
-@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/kamil\/workspace\/activecell_tactile\/src\/scss\/tactile\/_mixins\.scss}line{font-family:\00003171}}
+  /* line 171, /Users/sinisa/Workspaces/oDesk/Profitably/ActiveCell/Code/tactile/src/scss/tactile/_mixins.scss */
   #main-chart-legend .chart-legend:after {
     clear: both; }
-@media -sass-debug-info{filename{}line{font-family:\00003291}}
+  /* line 291 */
   #main-chart-legend .chart-legend li {
     float: left;
     text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.8);
     margin: 0 15px 5px 0; }
-@media -sass-debug-info{filename{}line{font-family:\00003296}}
+    /* line 296 */
     #main-chart-legend .chart-legend li span {
       display: inline-block;
       position: relative;
@@ -493,40 +493,40 @@
       height: 6px;
       border-radius: 1em;
       box-shadow: 1px 1px 0 rgba(255, 255, 255, 0.8), inset 1px 1px 1px rgba(0, 0, 0, 0.2); }
-@media -sass-debug-info{filename{}line{font-family:\00003305}}
+      /* line 305 */
       #main-chart-legend .chart-legend li span.point-noise {
         background-color: #a69b9e; }
-@media -sass-debug-info{filename{}line{font-family:\00003306}}
+      /* line 306 */
       #main-chart-legend .chart-legend li span.point-dogs {
         background-color: #dc6e59; }
-@media -sass-debug-info{filename{}line{font-family:\00003307}}
+      /* line 307 */
       #main-chart-legend .chart-legend li span.point-sprouts {
         background-color: #19affe; }
-@media -sass-debug-info{filename{}line{font-family:\00003308}}
+      /* line 308 */
       #main-chart-legend .chart-legend li span.point-stars {
         background-color: #8ac16f; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003314}}
+/* line 314 */
 .chart-legend {
   margin: 0 0 10px 10px;
   color: #404040;
   overflow: hidden; }
-@media -sass-debug-info{filename{}line{font-family:\00003319}}
+  /* line 319 */
   .chart-legend .legend-item {
     float: left;
     list-style: none;
     overflow: hidden;
     margin-right: 10px; }
-@media -sass-debug-info{filename{}line{font-family:\00003326}}
+    /* line 326 */
     .chart-legend .legend-item.off .text {
       color: #ccc; }
-@media -sass-debug-info{filename{}line{font-family:\00003331}}
+    /* line 331 */
     .chart-legend .legend-item:hover {
       cursor: pointer; }
-@media -sass-debug-info{filename{}line{font-family:\00003335}}
+    /* line 335 */
     .chart-legend .legend-item .color, .chart-legend .legend-item .text {
       float: left; }
-@media -sass-debug-info{filename{}line{font-family:\00003339}}
+    /* line 339 */
     .chart-legend .legend-item .color {
       border-radius: 3px;
       width: 6px;
@@ -534,13 +534,13 @@
       border: 1px solid #e6e6e6;
       margin-right: 8px;
       margin-top: 5px; }
-@media -sass-debug-info{filename{}line{font-family:\00003348}}
+    /* line 348 */
     .chart-legend .legend-item .text {
       font-size: 14px;
       line-height: 16px; }
 
 /* hover detail */
-@media -sass-debug-info{filename{}line{font-family:\00003357}}
+/* line 357 */
 .metric-inner-container .detail, .graph-container .detail {
   position: absolute;
   top: 0;
@@ -553,16 +553,16 @@
   -ms-transition: opacity 0.25s linear;
   -o-transition: opacity 0.25s linear;
   transition: opacity 0.25s linear; }
-@media -sass-debug-info{filename{}line{font-family:\00003366}}
+  /* line 366 */
   .metric-inner-container .detail.inactive, .graph-container .detail.inactive {
     opacity: 0; }
-@media -sass-debug-info{filename{}line{font-family:\00003370}}
+  /* line 370 */
   .metric-inner-container .detail.no-line, .graph-container .detail.no-line {
     background: none; }
-@media -sass-debug-info{filename{}line{font-family:\00003374}}
+  /* line 374 */
   .metric-inner-container .detail .item.active, .graph-container .detail .item.active {
     opacity: 1; }
-@media -sass-debug-info{filename{}line{font-family:\00003378}}
+  /* line 378 */
   .metric-inner-container .detail .x_label, .graph-container .detail .x_label {
     border-radius: 3px;
     padding: 6px;
@@ -572,7 +572,7 @@
     position: absolute;
     background: white;
     white-space: nowrap; }
-@media -sass-debug-info{filename{}line{font-family:\00003388}}
+  /* line 388 */
   .metric-inner-container .detail .item, .graph-container .detail .item {
     text-transform: none;
     position: absolute;
@@ -587,18 +587,18 @@
     margin-left: 1em;
     margin-top: -1em;
     white-space: nowrap; }
-@media -sass-debug-info{filename{}line{font-family:\00003402}}
+    /* line 402 */
     .metric-inner-container .detail .item.active, .graph-container .detail .item.active {
       opacity: 1;
       background: rgba(0, 0, 0, 0.8); }
-@media -sass-debug-info{filename{}line{font-family:\00003406}}
+    /* line 406 */
     .metric-inner-container .detail .item:before, .graph-container .detail .item:before {
       content: "\25c2";
       position: absolute;
       left: -0.5em;
       color: rgba(0, 0, 0, 0.7);
       width: 0; }
-@media -sass-debug-info{filename{}line{font-family:\00003414}}
+  /* line 414 */
   .metric-inner-container .detail .dot, .graph-container .detail .dot {
     width: 4px;
     height: 4px;
@@ -612,36 +612,36 @@
     border-style: solid;
     display: none;
     background-clip: padding-box; }
-@media -sass-debug-info{filename{}line{font-family:\00003427}}
+    /* line 427 */
     .metric-inner-container .detail .dot.active, .graph-container .detail .dot.active {
       display: block; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003434}}
+/* line 434 */
 .graph-container .tooltip {
   padding: 0;
   margin: 0;
   white-space: nowrap; }
-@media -sass-debug-info{filename{}line{font-family:\00003440}}
+/* line 440 */
 .graph-container .tooltip.right {
   padding-left: 5px;
   margin-left: 10px;
   margin-top: -11px; }
 
 /* sankey */
-@media -sass-debug-info{filename{}line{font-family:\00003454}}
+/* line 454 */
 .sankey-chart .node {
   stroke: #fff;
   stroke-width: 2px; }
-@media -sass-debug-info{filename{}line{font-family:\00003459}}
+/* line 459 */
 .sankey-chart .link {
   fill: none;
   stroke: #000;
   opacity: .3; }
-@media -sass-debug-info{filename{}line{font-family:\00003464}}
+/* line 464 */
 .sankey-chart .link.on {
   stroke: #F00;
   opacity: .7; }
-@media -sass-debug-info{filename{}line{font-family:\00003469}}
+/* line 469 */
 .sankey-chart .node {
   stroke: none; }
 
@@ -650,60 +650,60 @@
 /* http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute */
 /* You may find a better way to resize dynamically. */
 /* Please don't hesitate to contact me for any info: esbullington on github */
-@media -sass-debug-info{filename{}line{font-family:\00003484}}
+/* line 484 */
 .scatter circle.low {
   fill: #dc6e59; }
-@media -sass-debug-info{filename{}line{font-family:\00003485}}
+/* line 485 */
 .scatter circle.mid {
   fill: #19affe; }
-@media -sass-debug-info{filename{}line{font-family:\00003486}}
+/* line 486 */
 .scatter circle.high {
   fill: #8ac16f; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003490}}
+/* line 490 */
 .graph-container circle.tip-hovered {
   stroke-width: 1; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003495}}
+/* line 495 */
 .draggable-node-chart circle.selected, .draggable-node-chart circle:hover, .draggableLine circle.selected, .draggableLine circle:hover {
   fill: #f1d8a6; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003500}}
+/* line 500 */
 rect.colorless {
   fill: #5a6ca1; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003506}}
+/* line 506 */
 .ui-button {
   border: 1px solid #a69b9e;
   padding: 5px; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003512}}
+/* line 512 */
 path.colorless {
   stroke: #405192; }
-@media -sass-debug-info{filename{}line{font-family:\00003516}}
+/* line 516 */
 path.sparkline {
   stroke: #30878f;
   stroke-width: 1px;
   fill: none; }
-@media -sass-debug-info{filename{}line{font-family:\00003521}}
+/* line 521 */
 path.line {
   fill: none;
   stroke-width: 2px; }
-@media -sass-debug-info{filename{}line{font-family:\00003525}}
+/* line 525 */
 path.area {
   fill: #e7e7e7; }
 
-@media -sass-debug-info{filename{}line{font-family:\00003530}}
+/* line 530 */
 div.tipsy.help-tip.seg-tipsy .tipsy-inner div {
   padding: 6px; }
 
 /* Leaderboard */
-@media -sass-debug-info{filename{}line{font-family:\00003537}}
+/* line 537 */
 .leaderboard.label {
   fill: #a69b9e;
   font-size: 20px;
   font-weight: bold; }
-@media -sass-debug-info{filename{}line{font-family:\00003543}}
+/* line 543 */
 .leaderboard.value {
   font-size: 27px;
   fill: #3e3739;
@@ -711,46 +711,46 @@ div.tipsy.help-tip.seg-tipsy .tipsy-inner div {
   font-family: "ProximaNova", sans-serif;
   font-weight: 800;
   text-transform: uppercase; }
-@media -sass-debug-info{filename{}line{font-family:\00003550}}
+/* line 550 */
 .leaderboard.change {
   fill: #a69b9e;
   font-size: 12px;
   font-family: "ProximaNova", sans-serif;
   font-weight: bold;
   text-transform: uppercase; }
-@media -sass-debug-info{filename{}line{font-family:\00003556}}
+/* line 556 */
 .leaderboard .triangle-down {
   fill: #dc6e59;
   stroke: none; }
-@media -sass-debug-info{filename{}line{font-family:\00003561}}
+/* line 561 */
 .leaderboard .triangle-up {
   fill: #8ac16f;
   stroke: none; }
-@media -sass-debug-info{filename{}line{font-family:\00003566}}
+/* line 566 */
 .leaderboard.track {
   fill: #e2dedf;
   stroke: none; }
-@media -sass-debug-info{filename{}line{font-family:\00003571}}
+/* line 571 */
 .leaderboard.bar {
   fill: #30878f;
   stroke: none; }
 
 /* Gauge */
-@media -sass-debug-info{filename{}line{font-family:\00003580}}
+/* line 580 */
 .gauge.arc {
   fill: #e2dedf; }
-@media -sass-debug-info{filename{}line{font-family:\00003584}}
+/* line 584 */
 .gauge.arc-value {
   fill: #30878f; }
-@media -sass-debug-info{filename{}line{font-family:\00003588}}
+/* line 588 */
 .gauge.pointer-circle {
   fill: #faf9fa;
   stroke: #bfbfbf; }
-@media -sass-debug-info{filename{}line{font-family:\00003593}}
+/* line 593 */
 .gauge.pointer, .gauge.pointer-nail {
   stroke: none;
   fill: #4c4345; }
-@media -sass-debug-info{filename{}line{font-family:\00003598}}
+/* line 598 */
 .gauge.label {
   font-size: 27px;
   fill: #3e3739;
@@ -760,15 +760,15 @@ div.tipsy.help-tip.seg-tipsy .tipsy-inner div {
   text-transform: uppercase; }
 
 /*Bullet*/
-@media -sass-debug-info{filename{}line{font-family:\00003607}}
+/* line 607 */
 .bullet {
   font: 10px sans-serif; }
-@media -sass-debug-info{filename{}line{font-family:\00003609}}
+  /* line 609 */
   .bullet.title {
     font-size: 14px;
     font-weight: bold;
     fill: #3e3739; }
-@media -sass-debug-info{filename{}line{font-family:\00003615}}
+  /* line 615 */
   .bullet.subtitle {
     fill: #a69b9e;
     font-size: 10px; }

--- a/src/scss/tactile/_colors.scss
+++ b/src/scss/tactile/_colors.scss
@@ -1,29 +1,3 @@
-// Primary palette
-$primary:         #30878F;
-$primary-light:   #DAE1E9;
-$primary-dark:    #00455B;
-$secondary:       #005568;
-$secondary-light: lighten($secondary, 10%);
-$secondary-dark:  #013144;
-$green:           #c4d33e;
-$light-green:     #B4d037;
-$dark-green:      #99B718;
-
-$black:         #231F20;
-$dark-grey:     lighten($black, 25%);
-$grey:          lighten($black, 50%);
-$light-grey:    lighten($black, 75%);
-$lighter-grey:  lighten($black, 85%);
-$white:         #fff;
-
-$heading-grey:  #BFBFBF;
-$heading-black: #404040;
-
-$link-color: #006B75;
-
-$plan: lighten($primary-light, 15%);
-$border-grey: #e6e6e6;
-
 // Chart palette
 $dark-blue-10: #0B3748;
 $dark-blue-20: #254E5D;
@@ -94,15 +68,3 @@ $dark-grey-30: #5A5B5B;
 $dark-grey-40: #676868;
 $dark-grey-50: #747474;
 $dark-grey-60: #818181;
-
-// Alert palette
-$success:         #8ac16f; // sampled from air psd
-$success-light:   #e7ffdc; // sampled from air psd
-$warning:         #eedc94; // sampled from air psd
-$warning-light:   #fce5b1; // sampled from air psd
-$danger:          #dc6e59; // sampled from air psd
-$danger-light:    #ffdacf; // sampled from air psd
-$info:            #19affe; // sampled from air psd
-$info-light:      #b8f6ff; // sampled from air psd
-$inverse:         $dark-grey-50;
-$inverse-light:   $light-grey;

--- a/src/scss/tactile/tactile.scss
+++ b/src/scss/tactile/tactile.scss
@@ -1,4 +1,3 @@
-@import "colors";
 @import "tactile_colors";
 @import "mixins";
 


### PR DESCRIPTION
# WIP

@Aluman this is a pull request for [this](https://trello.com/c/JIJWTybK) card.

I will try to be as more specific as I can about what need's to be done. SO here we go :dancers: 
## Chart palette:

is a set of 10 colors. Every set has 5 shades of a color. I.E:

```
$blue-10: #0C1B75;
$blue-20: #263683;
$blue-30: #405192;
$blue-40: #5A6CA1;
$blue-50: #7487B0;
$blue-60: #8FA3BF;
```

**We need an array/hash with css classes. One array which contains all sets and each set is an array that contains all shades of a color (css classes).**

something like this:

```
chartColors: {
  blue {
    10: ".tactile-blue-10"
    20: ".tactile-blue-20"
    30: ".tactile-blue-30"
    40: ".tactile-blue-40"
    50: ".tactile-blue-50"
    60: ".tactile-blue-60"
  }
  ...
}
```

then those classes should be applied on the chart elements. I insist on css classes because it would be much easier to change/update colors in the future that a way.

@adamrneary Can you please confirm above written and/or add/change something?
